### PR TITLE
Adds optional support for the stable_deref_trait crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ description = "Poison-free versions of the standard library Mutex and RwLock typ
 repository = "https://github.com/sfackler/rust-antidote"
 documentation = "https://sfackler.github.io/rust-antidote/doc/v1.0.0/antidote"
 readme = "README.md"
+
+[dependencies]
+stable_deref_trait = { version = "1.2.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,9 @@ impl<T: Default> Default for Mutex<T> {
     }
 }
 
+#[cfg(feature = "stable_deref_trait")]
+unsafe impl<'a, T: ?Sized> stable_deref_trait::StableDeref for MutexGuard<'a, T> {} 
+
 /// Like `std::sync::Condvar`.
 pub struct Condvar(sync::Condvar);
 


### PR DESCRIPTION
This allows using the [`owning_ref`](https://docs.rs/owning_ref/latest/owning_ref/) crate with Antidote.