### PR TITLE
chore: release v2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "antidote"
-version = "1.0.0"
+version = "2.0.0"
+edition = "2021"
+rust-version = "1.63"
+
+# Metadata for publication
 authors = ["Steven Fackler <sfackler@gmail.com>"]
-license = "MIT/Apache-2.0"
 description = "Poison-free versions of the standard library Mutex and RwLock types"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/sfackler/rust-antidote"
-documentation = "https://sfackler.github.io/rust-antidote/doc/v1.0.0/antidote"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rust-antidote
 
-[Documentation](https://sfackler.github.io/rust-antidote/doc/v1.0.0/antidote)
+[Documentation](https://docs.rs/antidote/latest/antidote/)
 
 Poison-free versions of the Rust standard library `Mutex` and `RwLock` types.
 
@@ -12,6 +12,10 @@ Licensed under either of
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
+
+## MSRV
+
+1.63.0
 
 ### Contribution
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+edition = "2021"
+format_code_in_doc_comments = true
+format_strings = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+max_width = 100
+merge_derives = false
+normalize_comments = true
+normalize_doc_attributes = true
+wrap_comments = true


### PR DESCRIPTION
Including the following:

- add rustfmt, and then cargo fmt & cargo clippy
- **Main feature** make Mutex::new or RwLock::new const 
- set MSRV to 1.63 (when Mutex::new or RwLock::new const stable)
- set Rust edition to 2021
- serve document with docs.rs
- make wrapper struct repr transparent
